### PR TITLE
Accept MM:SS format for start and end positions

### DIFF
--- a/looper.sh
+++ b/looper.sh
@@ -20,12 +20,22 @@ function control_c {
     exit
 }
 
+function to_secs() {
+    secs=${1#*:}
+    mins=${1%:*}
+    [ $secs -eq $mins ] && { echo $secs; return; }
+    echo $(( 60 * $mins + $secs ))
+}
+
 read TRACK_URI START_POS END_POS < "$1"
+START_SEC=$(to_secs $START_POS)
+END_SEC=$(to_secs $END_POS)
+
 echo "Looping $1"
 echo "Track `echo $TRACK_URI | sed s/spotify:/spotify:\\\\/\\\\//`"
 echo "From $START_POS to $END_POS"
 
-POS_DIFF="$(($END_POS-$START_POS))"
+SEC_DIFF="$(($END_SEC-$START_SEC))"
 
 tell_spotify_to "get sound volume"
 
@@ -33,7 +43,7 @@ tell_spotify_to "get sound volume"
 CURRENT_VOLUME=$(($output+1))
 
 debug "Current volume $CURRENT_VOLUME"
-debug "Diff position $POS_DIFF"
+debug "Diff position $SEC_DIFF"
 
 trap control_c SIGINT
 trap control_c SIGTERM
@@ -43,7 +53,7 @@ tell_spotify_to "play track \\\"$TRACK_URI\\\""
 
 while [ 1 ]
 do
-    tell_spotify_to "set player position to $START_POS"
+    tell_spotify_to "set player position to $START_SEC"
     tell_spotify_to "set sound volume to $CURRENT_VOLUME"
-    sleep $POS_DIFF
+    sleep $SEC_DIFF
 done

--- a/looper.sh
+++ b/looper.sh
@@ -21,8 +21,8 @@ function control_c {
 }
 
 function to_secs() {
-    secs=${1#*:}
-    mins=${1%:*}
+    secs=$((10#${1#*:}))
+    mins=$((10#${1%:*}))
     [ $secs -eq $mins ] && { echo $secs; return; }
     echo $(( 60 * $mins + $secs ))
 }


### PR DESCRIPTION
If the given start or stop positions contain a semicolon, assume MM:SS
format. This is the format Spotify UI shows when playing back a song, so
it is more convenient than raw seconds.

If no semicolon is present, assume the given input is in seconds, as
previously.